### PR TITLE
Correct endpoints for readiness and liveness probes

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -90,7 +90,7 @@
               livenessProbe:
                 failureThreshold: 3
                 httpGet:
-                  path: /metrics
+                  path: /liveness
                   port: 9187
                   scheme: HTTP
                 initialDelaySeconds: 5
@@ -100,7 +100,7 @@
               readinessProbe:
                 failureThreshold: 3
                 httpGet:
-                  path: /metrics
+                  path: /readiness
                   port: 9187
                   scheme: HTTP
                 initialDelaySeconds: 5


### PR DESCRIPTION
I already included changes in https://github.com/thoth-station/ansible-role-postgresql-metrics-exporter/pull/3, so that can be closed if we want. 

Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>